### PR TITLE
update github addresses

### DIFF
--- a/app/(components)/Navbar/Navbar.tsx
+++ b/app/(components)/Navbar/Navbar.tsx
@@ -165,7 +165,7 @@ export function Navbar() {
                 </Box>
                 <Button
                   as={Link}
-                  href="https://github.com/fariapp/fari-community"
+                  href="https://github.com/farirpgs/fari-community"
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/app/(pages)/creators/[creatorSlug]/pure.tsx
+++ b/app/(pages)/creators/[creatorSlug]/pure.tsx
@@ -67,7 +67,7 @@ export function CreatorPage(props: {
           leftIcon={<EditIcon />}
           size="md"
           as="a"
-          href={`https://github.com/fariapp/fari-community/edit/main/public/catalog/creators/${props.creator.creatorSlug}/index.ts`}
+          href={`https://github.com/farirpgs/fari-community/edit/main/public/catalog/creators/${props.creator.creatorSlug}/index.ts`}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/public/catalog/creators/fari-rpgs/fari-app-wiki/index.md
+++ b/public/catalog/creators/fari-rpgs/fari-app-wiki/index.md
@@ -540,22 +540,24 @@ Otherwise, take a look at the other options for translating Fari programmaticall
 
 ## Adding a new language to Fari
 
-To add a new language to Fari, you can download the [English translation file](https://github.com/fariapp/fari/blob/master/locales/en.json) and update the values of each key.
+To add a new language to Fari, you can download the [English translation file](https://github.com/farirpgs/fari-app/blob/master/public/locales/en/translation.json) and update the values of each key.
 
-Once the file is translated, [open a feature request](https://github.com/fariapp/fari/issues/new/choose) and upload the new file in the issue.
+Once the file is translated, [open a feature request](https://github.com/farirpgs/fari-app/issues/new/choose) and upload the new file in the issue.
 
 A developer will then integrate the file into the application.
 
 ## Updating a translation value
 
-It's possible that something in the app was badly translated, in that case, you can find the proper [language file](https://github.com/fariapp/fari/tree/master/locales/en.json) and open an issue to say which key needs to be updated and what should be the new value.
+It's possible that something in the app was badly translated, in that case, you can find the proper [language file](https://github.com/farirpgs/fari-app/blob/master/public/locales/en/translation.json) and open an issue to say which key needs to be updated and what should be the new value.
 
 Also, try to include the reason why the original value was not good.
 
 ## About Page
 
 The About page is not translated using the translations keys like the rest of the pages, it instead uses one markdown file per language which is saved in [this folder](https://github.com/fariapp/fari/tree/master/lib/routes/About/page).
+<!-- The link above is out of date -->
 
 If you want to translate the app, you should also provide a translated version of the About page in markdown format.
 
 To do so, you can [download the English About page](https://raw.githubusercontent.com/fariapp/fari/master/lib/routes/About/page/About.en.md) and translate its content in the language of your choice.
+<!-- The link above is out of date -->

--- a/public/catalog/creators/fari-rpgs/fari-community/index.md
+++ b/public/catalog/creators/fari-rpgs/fari-community/index.md
@@ -10,7 +10,7 @@ If you are looking to **add your own content** to the site, there are two ways y
 
 ## I'm Familiar with Git and Markdown
 
-If you are familiar with Git and Markdown, you can [**fork the Fari Community repository**](https://github.com/fariapp/fari-community) and read the content of this wiki to learn how to add your own content and how the site is structured.
+If you are familiar with Git and Markdown, you can [**fork the Fari Community repository**](https://github.com/farirpgs/fari-community) and read the content of this wiki to learn how to add your own content and how the site is structured.
 
 ## I'm Not Familiar with Git and Markdown
 
@@ -85,7 +85,7 @@ This is an image that will be used to represent the project on the site. The ima
 
 e.g.
 
-<img src="https://raw.githubusercontent.com/fariapp/fari-community/main/public/catalog/creators/fari-rpgs/breathless/image.png" width='200px'/>
+<img src="https://raw.githubusercontent.com/farirpgs/fari-community/main/public/catalog/creators/fari-rpgs/breathless/image.png" width='200px'/>
 
 #### Project content (Required)
 
@@ -182,7 +182,7 @@ Once you have all the information ready, you can send it to us by creating a new
 
 # Structure | Site Management
 
-The Fari Community's site is all based on the file structure of the [`public/catalog`](https://github.com/fariapp/fari-community/tree/main/public/catalog) folder.
+The Fari Community's site is all based on the file structure of the [`public/catalog`](https://github.com/farirpgs/fari-community/tree/main/public/catalog) folder.
 
 The folder names and files found within this folder are used to generate the site's navigation.
 
@@ -219,7 +219,7 @@ This section goes over how to add or update a creator to the site.
 
 ## Creating the Creator's Space
 
-To add a new creator, you need to create a new folder in the [`public/catalog/creators`](https://github.com/fariapp/fari-community/tree/main/public/catalog/creators) folder.
+To add a new creator, you need to create a new folder in the [`public/catalog/creators`](https://github.com/farirpgs/fari-community/tree/main/public/catalog/creators) folder.
 
 The folder name should be the creator's identifier. This identifier is used to generate the URL of the creator's page, and should be written in `kebab-case` (lowercase with hyphens).
 
@@ -264,7 +264,7 @@ This section goes over how to add or update a project to the site.
 
 ## Creating the Project's Space
 
-To add a new project, you need to create a new folder in the [`public/catalog/creators/{creator-identifier}`](https://github.com/fariapp/fari-community/tree/main/public/catalog/creators) folder.
+To add a new project, you need to create a new folder in the [`public/catalog/creators/{creator-identifier}`](https://github.com/farirpgs/fari-community/tree/main/public/catalog/creators) folder.
 
 The folder name should be the project's identifier. This identifier is used to generate the URL of the project's page, and should be written in `kebab-case` (lowercase with hyphens).
 

--- a/public/catalog/creators/fari-rpgs/fari-community/index.ts
+++ b/public/catalog/creators/fari-rpgs/fari-community/index.ts
@@ -5,7 +5,7 @@ export default function getData(): IProjectData {
     name: "Fari Community",
     description: "Get started in using the Fari Community website.",
     links: {
-      GitHub: "https://github.com/fariapp/fari-community",
+      GitHub: "https://github.com/farirpgs/fari-community",
       Discord: "https://farirpgs.com/discord",
     },
   };


### PR DESCRIPTION
Various points still go to 'fariapp/github' rather than  'farirpgs/github'.

I've updated most of the links to 'farirpgs/fari-app' appropriately, but two (noted in a markdown comment) don't have any direct parallel.